### PR TITLE
Present editor as full screen on iOS 13

### DIFF
--- a/MrHappyoI/View/Browser/DocumentBrowserViewController.swift
+++ b/MrHappyoI/View/Browser/DocumentBrowserViewController.swift
@@ -96,6 +96,7 @@ public class DocumentBrowserViewController: UIDocumentBrowserViewController, UID
         editorViewController.loadViewIfNeeded()
 
         navViewController.transitioningDelegate = self
+        navViewController.modalPresentationStyle = .fullScreen
         let transitioningController = transitionController(forDocumentAt: documentURL)
         transitioningController.targetView = editorViewController.slideViewController.slideView
         self.transitioningController = transitioningController


### PR DESCRIPTION
When building against iOS 13 SDK, the editor is presented in card sheet style.
This PR lets editor shown in full screen style.